### PR TITLE
Fix CodeQL analysis fail

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -54,12 +54,14 @@ jobs:
         shell: pwsh
         run: |
           msbuild $env:PROJECT_PATH `
+          /p:Platform=$env:PLATFORM `
           /p:Configuration=$env:CONFIGURATION `
           /p:UapAppxPackageBuildMode=$env:APPX_PACKAGE_BUILD_MODE `
           /p:AppxBundle=$env:APPX_BUNDLE `
           /p:AppxPackageSigningEnabled=false `
           /p:AppxBundlePlatforms="$env:APPX_BUNDLE_PLATFORMS"
         env:
+          PLATFORM: x64
           APPX_PACKAGE_BUILD_MODE: StoreUpload
           APPX_BUNDLE: Always
           APPX_BUNDLE_PLATFORMS: x64


### PR DESCRIPTION
- add explicit platform (x64) parameter to the build step