### PR TITLE
Add AppCenterSecret assignment in build process from GitHub Secrets AB#325

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -185,7 +185,7 @@ jobs:
           ARTIFACTS_DIR: ${{ github.workspace }}\Artifacts
           PACKAGE_CERTIFICATE_KEYFILE: ${{ github.workspace }}\cert.pfx
           PACKAGE_CERTIFICATE_PASSWORD: ${{ secrets.PACKAGE_CERTIFICATE_PWD }}
-          APP_CENTER_SECRET: ${{ secrets.APP_CENTER_SECRET }}
+          APP_CENTER_SECRET: 15336463463456
 
       - if: steps.step_conditionals_handler.outputs.is_not_pr == 'true'
         name: Send SonarCloud results

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -163,6 +163,7 @@ jobs:
 
       - name: Build and generate bundles
         id: build_app
+        continue-on-error: true
         shell: pwsh
         run: |
           msbuild $env:SOLUTION_NAME `
@@ -198,13 +199,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.SONAR_GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
-      - if: steps.step_conditionals_handler.outputs.is_push_to_master == 'true'
-        name: Upload build artifacts
-        id: upload_artifacts
-        uses: actions/upload-artifact@v1
-        with:
-          name: Build artifacts
-          path: Artifacts/
+      # - if: steps.step_conditionals_handler.outputs.is_push_to_master == 'true'
+      #   name: Upload build artifacts
+      #   id: upload_artifacts
+      #   uses: actions/upload-artifact@v1
+      #   with:
+      #     name: Build artifacts
+      #     path: Artifacts/
 
       - name: Upload build artifacts
         id: upload_app_xaml_cs

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -207,7 +207,7 @@ jobs:
           path: Artifacts/
 
       - name: Upload build artifacts
-        id: upload_artifacts
+        id: upload_app_xaml_cs
         uses: actions/upload-artifact@v1
         with:
           name: App.xaml.cs

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -163,7 +163,6 @@ jobs:
 
       - name: Build and generate bundles
         id: build_app
-        continue-on-error: true
         shell: pwsh
         run: |
           msbuild $env:SOLUTION_NAME `
@@ -199,20 +198,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.SONAR_GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
-      # - if: steps.step_conditionals_handler.outputs.is_push_to_master == 'true'
-      #   name: Upload build artifacts
-      #   id: upload_artifacts
-      #   uses: actions/upload-artifact@v1
-      #   with:
-      #     name: Build artifacts
-      #     path: Artifacts/
-
-      - name: Upload build artifacts
-        id: upload_app_xaml_cs
+      - if: steps.step_conditionals_handler.outputs.is_push_to_master == 'true'
+        name: Upload build artifacts
+        id: upload_artifacts
         uses: actions/upload-artifact@v1
         with:
-          name: App.xaml.cs
-          path: src/Notepads/App.xaml.cs
+          name: Build artifacts
+          path: Artifacts/
 
   cd:
     # "This job will execute when the workflow is triggered on a 'push event', the target branch is 'master' and the commit is intended to be a release."

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -185,7 +185,7 @@ jobs:
           ARTIFACTS_DIR: ${{ github.workspace }}\Artifacts
           PACKAGE_CERTIFICATE_KEYFILE: ${{ github.workspace }}\cert.pfx
           PACKAGE_CERTIFICATE_PASSWORD: ${{ secrets.PACKAGE_CERTIFICATE_PWD }}
-          APP_CENTER_SECRET: 15336463463456
+          APP_CENTER_SECRET: "15336463463456"
 
       - if: steps.step_conditionals_handler.outputs.is_not_pr == 'true'
         name: Send SonarCloud results

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -174,7 +174,8 @@ jobs:
           /p:AppxBundlePlatforms=$env:APPX_BUNDLE_PLATFORMS `
           /p:AppxPackageDir=$env:ARTIFACTS_DIR `
           /p:PackageCertificateKeyFile=$env:PACKAGE_CERTIFICATE_KEYFILE `
-          /p:PackageCertificatePassword=$env:PACKAGE_CERTIFICATE_PASSWORD
+          /p:PackageCertificatePassword=$env:PACKAGE_CERTIFICATE_PASSWORD `
+          /p:AppCenterSecret=$env:APP_CENTER_SECRET
         env:
           PLATFORM: x64
           UAP_APPX_PACKAGE_BUILD_MODE: StoreUpload
@@ -184,6 +185,7 @@ jobs:
           ARTIFACTS_DIR: ${{ github.workspace }}\Artifacts
           PACKAGE_CERTIFICATE_KEYFILE: ${{ github.workspace }}\cert.pfx
           PACKAGE_CERTIFICATE_PASSWORD: ${{ secrets.PACKAGE_CERTIFICATE_PWD }}
+          APP_CENTER_SECRET: ${{ secrets.APP_CENTER_SECRET }}
 
       - if: steps.step_conditionals_handler.outputs.is_not_pr == 'true'
         name: Send SonarCloud results
@@ -203,6 +205,13 @@ jobs:
         with:
           name: Build artifacts
           path: Artifacts/
+
+      - name: Upload build artifacts
+        id: upload_artifacts
+        uses: actions/upload-artifact@v1
+        with:
+          name: App.xaml.cs
+          path: src/Notepads/App.xaml.cs
 
   cd:
     # "This job will execute when the workflow is triggered on a 'push event', the target branch is 'master' and the commit is intended to be a release."

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -186,7 +186,7 @@ jobs:
           ARTIFACTS_DIR: ${{ github.workspace }}\Artifacts
           PACKAGE_CERTIFICATE_KEYFILE: ${{ github.workspace }}\cert.pfx
           PACKAGE_CERTIFICATE_PASSWORD: ${{ secrets.PACKAGE_CERTIFICATE_PWD }}
-          APP_CENTER_SECRET: "15336463463456"
+          APP_CENTER_SECRET: ${{ secrets.APP_CENTER_SECRET }}
 
       - if: steps.step_conditionals_handler.outputs.is_not_pr == 'true'
         name: Send SonarCloud results

--- a/src/Notepads/App.xaml.cs
+++ b/src/Notepads/App.xaml.cs
@@ -31,7 +31,7 @@
         public static bool IsPrimaryInstance = false;
         public static bool IsGameBarWidget = false;
 
-        private const string AppCenterSecret = "Assign_AppCenterSecret_From_MSBuild";
+        private const string AppCenterSecret = null;
 
         public static Mutex InstanceHandlerMutex { get; set; }
 

--- a/src/Notepads/App.xaml.cs
+++ b/src/Notepads/App.xaml.cs
@@ -31,7 +31,7 @@
         public static bool IsPrimaryInstance = false;
         public static bool IsGameBarWidget = false;
 
-        private const string AppCenterSecret = "15336463463456";
+        private const string AppCenterSecret = 'Assign_AppCenterSecret_From_MSBuild';
 
         public static Mutex InstanceHandlerMutex { get; set; }
 

--- a/src/Notepads/App.xaml.cs
+++ b/src/Notepads/App.xaml.cs
@@ -31,7 +31,7 @@
         public static bool IsPrimaryInstance = false;
         public static bool IsGameBarWidget = false;
 
-        private const string AppCenterSecret = null;
+        private const string AppCenterSecret = Assign_AppCenterSecret_From_MSBuild;
 
         public static Mutex InstanceHandlerMutex { get; set; }
 

--- a/src/Notepads/App.xaml.cs
+++ b/src/Notepads/App.xaml.cs
@@ -31,7 +31,7 @@
         public static bool IsPrimaryInstance = false;
         public static bool IsGameBarWidget = false;
 
-        private const string AppCenterSecret = Assign_AppCenterSecret_From_MSBuild;
+        private const long AppCenterSecret = Assign_AppCenterSecret_From_MSBuild;
 
         public static Mutex InstanceHandlerMutex { get; set; }
 

--- a/src/Notepads/App.xaml.cs
+++ b/src/Notepads/App.xaml.cs
@@ -31,7 +31,7 @@
         public static bool IsPrimaryInstance = false;
         public static bool IsGameBarWidget = false;
 
-        private const string AppCenterSecret = Assign_AppCenterSecret_From_MSBuild;
+        private const string AppCenterSecret = "15336463463456";
 
         public static Mutex InstanceHandlerMutex { get; set; }
 

--- a/src/Notepads/App.xaml.cs
+++ b/src/Notepads/App.xaml.cs
@@ -31,7 +31,7 @@
         public static bool IsPrimaryInstance = false;
         public static bool IsGameBarWidget = false;
 
-        private const string AppCenterSecret = 'Assign_AppCenterSecret_From_MSBuild';
+        private const string AppCenterSecret = "Assign_AppCenterSecret_From_MSBuild";
 
         public static Mutex InstanceHandlerMutex { get; set; }
 

--- a/src/Notepads/App.xaml.cs
+++ b/src/Notepads/App.xaml.cs
@@ -31,7 +31,7 @@
         public static bool IsPrimaryInstance = false;
         public static bool IsGameBarWidget = false;
 
-        private const long AppCenterSecret = Assign_AppCenterSecret_From_MSBuild;
+        private const string AppCenterSecret = Assign_AppCenterSecret_From_MSBuild;
 
         public static Mutex InstanceHandlerMutex { get; set; }
 

--- a/src/Notepads/Notepads.csproj
+++ b/src/Notepads/Notepads.csproj
@@ -462,7 +462,7 @@
     </PropertyGroup>
     <WriteLinesToFile
         File="$(InputFile)"
-        Lines="$([System.IO.File]::ReadAllText($(InputFile)).Replace('AppCenterSecret = null','AppCenterSecret = "$(AppCenterSecret)"'))"
+        Lines="$([System.IO.File]::ReadAllText($(InputFile)).Replace('AppCenterSecret = null','AppCenterSecret = &quot;$(AppCenterSecret)&quot;'))"
         Overwrite="true"
         Encoding="Unicode"/>
   </Target>

--- a/src/Notepads/Notepads.csproj
+++ b/src/Notepads/Notepads.csproj
@@ -456,6 +456,16 @@
       <AppxManifest Include="$(GeneratedAppxManifest)" />
     </ItemGroup>
   </Target>
+  <Target Name="AssignAppCenterSecret" BeforeTargets="BeforeBuild" Condition=" $(AppCenterSecret) != '' ">
+    <PropertyGroup>
+      <InputFile>App.xaml.cs</InputFile>
+    </PropertyGroup>
+    <WriteLinesToFile
+        File="$(InputFile)"
+        Lines="$([System.IO.File]::ReadAllText($(InputFile)).Replace('Assign_AppCenterSecret_From_MSBuild','$(AppCenterSecret)'))"
+        Overwrite="true"
+        Encoding="Unicode"/>
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/Notepads/Notepads.csproj
+++ b/src/Notepads/Notepads.csproj
@@ -462,7 +462,7 @@
     </PropertyGroup>
     <WriteLinesToFile
         File="$(InputFile)"
-        Lines="$([System.IO.File]::ReadAllText($(InputFile)).Replace('Assign_AppCenterSecret_From_MSBuild','$(AppCenterSecret)'))"
+        Lines="$([System.IO.File]::ReadAllText($(InputFile)).Replace('AppCenterSecret = null','AppCenterSecret = "$(AppCenterSecret)"'))"
         Overwrite="true"
         Encoding="Unicode"/>
   </Target>


### PR DESCRIPTION
- add "Assign_AppCenterSecret_From_MSBuild" as placeholder for AppCenterSecret variable in App.xaml.cs
- add /p:AppCenterSecret=$env:APP_CENTER_SECRET parameter with ${{ secrets.APP_CENTER_SECRET }} as value
- add Target "AssignAppCenterSecret" in Notepads.csproj, that executes before any other declared targets, which takes the value of the /p:AppCenterSecret parameter and replaces the "Assign_AppCenterSecret_From_MSBuild" placeholder in App.xaml.cs
- during the run **in the original repo ONLY**, the value of ${{ secrets.APP_CENTER_SECRET }} is exposed to anyone with permissions to change and commit files, by adding a step to the main workflow to upload the App.xaml.cs file as artifact